### PR TITLE
Old rubies

### DIFF
--- a/base45_lite.gemspec
+++ b/base45_lite.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.description = 'base45_lite is a Ruby implementation of Base45 data encoding'
   spec.homepage = 'https://github.com/tonytonyjan/base45_lite'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.3.0'
   spec.files = Dir['lib/**/*.rb']
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/base45_lite.rb
+++ b/lib/base45_lite.rb
@@ -50,12 +50,12 @@ module Base45Lite
       _, d = i.divmod(45)
       sequence.push(c, d)
     end
-    sequence.map!{ MAPPING[_1] }.join
+    sequence.map!{ |n| MAPPING[n] }.join
   end
 
   def self.decode(input)
     input
-      .chars.map! { REVERSE_MAPPING[_1] || raise(InvalidCharacterError) }
+      .chars.map! { |c| REVERSE_MAPPING[c] || raise(InvalidCharacterError) }
       .each_slice(3).map do |slice|
         c, d, e = slice
         raise ForbiddenLengthError if d.nil?


### PR DESCRIPTION
Tested with 2.3.0, 2.4.9, 2.5.8, 2.6.9, 2.7.5, 3.0.5, 3.2.1
(2.3.0 is the oldest Ruby version I'm still trying to support.)

Note that the entry in the gemspec previously was wrong; 2.6 does not have named parameters yet.
This should have said 2.7.
